### PR TITLE
fix tensor error

### DIFF
--- a/di_baseline/my_submission/entry/gobigger_vsbot_baseline_main.py
+++ b/di_baseline/my_submission/entry/gobigger_vsbot_baseline_main.py
@@ -51,6 +51,7 @@ class RulePolicy:
             action = []
             for o in data[env_id]:   # len(data[env_id]) = player_num_per_team
                 raw_obs = o['collate_ignore_raw_obs']
+                raw_obs['overlap']['clone'] = [[x[0], x[1], x[2], int(x[3]), int(x[4])]  for x in raw_obs['overlap']['clone']]
                 key = str(int(o['player_name']))
                 bot = self.bot[key]
                 action.append(bot.step(raw_obs))

--- a/di_baseline/my_submission/entry/gobigger_vsbot_baseline_main.py
+++ b/di_baseline/my_submission/entry/gobigger_vsbot_baseline_main.py
@@ -51,7 +51,7 @@ class RulePolicy:
             action = []
             for o in data[env_id]:   # len(data[env_id]) = player_num_per_team
                 raw_obs = o['collate_ignore_raw_obs']
-                key = o['player_name']
+                key = str(int(o['player_name']))
                 bot = self.bot[key]
                 action.append(bot.step(raw_obs))
             ret[env_id] = {'action': np.array(action)}

--- a/di_baseline/my_submission/envs/gobigger_env.py
+++ b/di_baseline/my_submission/envs/gobigger_env.py
@@ -76,6 +76,8 @@ class GoBiggerEnv(BaseEnv):
         self._env.reset()
         raw_obs = self._env.obs()
         obs = self._obs_transform(raw_obs)
+        self._last_team_size = None
+        rew = self._get_reward(raw_obs)
         return obs
 
     def close(self) -> None:
@@ -173,14 +175,14 @@ class GoBiggerEnv(BaseEnv):
                 player_unit_feat = np.concatenate([player_unit_feat, padding_player_unit_feat])
             else:
                 player_unit_feat = np.stack(player_unit_feat)[-200:]
-
+            raw_overlap['clone'] = [[x[0],x[1],x[2],int(x[3]),int(x[4])]for x in raw_overlap['clone']]
             obs.append(
                 {
                     'scalar_obs': np.concatenate([global_feat, player_scalar_feat]).astype(np.float32),
                     'unit_obs': player_unit_feat.astype(np.float32),
                     'unit_num': len(player_unit_feat),
                     'collate_ignore_raw_obs': copy.deepcopy({'overlap': raw_overlap}),
-                    'player_name':n,
+                    'player_name':int(n),
                     'team_name':int(value['team_name'][-1]),
                 }
             )


### PR DESCRIPTION
 1. raw_overlap['clone']  is used by BotAgent. In collector, there is no "to_tensor", but in evaluator, there is "to_tensor" , So we need to adopt this method( int(torch.Tensor())) to unify them.